### PR TITLE
Add code support for running HTTPSWatch in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM alpine:latest
+MAINTAINER Antonios A. Chariton <daknob@daknob.net>
+
+# Install Python 3, pip, and lxml dependencies
+RUN apk add --update    python3 \
+                        python3-dev \
+                        build-base \
+                        libxml2 \
+                        libxslt \
+                        libxml2-dev \
+                        libxslt-dev \
+                        py-libxml2 \
+                        py-libxslt 
+RUN python3 -m ensurepip
+RUN pip3 install --upgrade pip setuptools
+
+# Move everything inside the image
+RUN mkdir /httpswatch
+COPY . /httpswatch/.
+WORKDIR /httpswatch
+
+# Install the required python modules
+RUN pip3 install -r requirements.txt
+
+# Expose port 80
+EXPOSE 80
+
+# Expose configuration volume
+VOLUME ["/httpswatch/config/"]
+
+# Install nginx
+RUN apk add nginx
+
+# Configure nginx
+COPY ./docker/nginx.conf /etc/nginx/nginx.conf
+
+# Move Docker Scripts
+COPY ./docker/run.sh /bin/run.sh
+COPY ./docker/periodic-checks.sh /bin/periodic-checks.sh
+
+# Run nginx + periodic checker
+CMD ["/bin/run.sh"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,32 @@
+worker_processes  1;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    server {
+        listen       80;
+        server_name  localhost;
+        index  index.html index.htm;
+
+        location / {
+            root   /httpswatch/out;
+            try_files $uri $uri.html /index.html;
+        }
+
+        location /static/ {
+            root /httpswatch;
+        }
+
+    }
+
+}

--- a/docker/periodic-checks.sh
+++ b/docker/periodic-checks.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+export SLEEP=86400
+
+echo "Periodic Checker launched!"
+while :; do
+    echo "Checking for all websites on $(date)...";
+    ./check_https.py;
+    echo "Done checking on $(date).";
+    echo "Sleeping for $SLEEP seconds...";
+    sleep $SLEEP;
+    echo "Done!"
+done

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Launching periodic checker..."
+/bin/periodic-checks.sh &
+echo "Done"
+echo "Launching nginx..."
+nginx -g "daemon off;"


### PR DESCRIPTION
This Pull Request adds support for [Docker](https://docker.com) in HTTPS Watch. The way this is achieved is by creating a new `docker` image with all the files and then installing the dependencies included in `requirements.txt`. The image uses `python3.5`. As soon as the image is executed (in a container), two processes start. The first is a bash script, namely `/bin/periodic-check.sh`, which currently runs `check_https.py` every 24 hours in the background. The second is the `nginx` web server, properly configured to serve `/out` and `/static` in port 80.
By default, if you don't pass any extra arguments to `docker`, it will run with the `/config` included in this repository. However, to allow for easy editing of the configuration file, a `docker` volume is exposed, namely `/httpswatch/config/`, so by using `docker run` with `-v /path/to/config:/httpswatch/config/` the configuration file can be overrided with a new one. If you decide to do this, every time you make a change to the configuration file in the host, the `docker` container will use the new configuration file, just like a `cron` job. 

###How to build the Docker Image:

Just run:
```bash
docker build -t benjaminp/httpswatch .
```

###How to run a built image:

To run HTTPSWatch with the default configuration file on port `tcp/8000`, use the following:
```bash
docker run -p 8000:80 --rm --name httpswatch benjaminp/httpswatch
```

To run HTTPSWatch with a custom configuration file, use:
```bash
docker run -p 8000:80 --rm --name httpswatch -v /path/to/config:/httpswatch/config/ benjamin/httpswatch
```

In any case, if you want to run HTTPSWatch in the background, you can also add `-d`. If you also want to restart automatically the container across host reboots / `docker` upgrades, remove the `--rm` and add the `--restart=always`. 